### PR TITLE
Add partial support for Chromium browsers

### DIFF
--- a/background.js
+++ b/background.js
@@ -30,7 +30,7 @@ let bangs = {};
   bangs["bang"] = bangs["bangs"];
 })();
 
-browser.webRequest.onBeforeRequest.addListener(
+chrome.webRequest.onBeforeRequest.addListener(
   (details) => {
     const url = new URL(details.url);
 
@@ -93,8 +93,8 @@ function updateTab(tabId, url) {
     url: url,
   };
   if (tabId != null) {
-    browser.tabs.update(tabId, updateProperties);
+    chrome.tabs.update(tabId, updateProperties);
   } else {
-    browser.tabs.update(updateProperties);
+    chrome.tabs.update(updateProperties);
   }
 }


### PR DESCRIPTION
This adds partial support for chromium-based browsers (including Google Chrome). `window.browser` is only defined in firefox but `window.chrome` is available both in firefox and chromium and works just the same.

This only partially supports chromium as `loadReplace` is not supported in chromium:
- https://github.com/dmlls/yang/blob/6dd101e9a27e8620ffe8fa7641b00ee8e8ef42e8/background.js#L92
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/Tabs/update#browser_compatibility

I am not aware of workarounds for `loadReplace`, thus to make it work on chromium-based browsers it requires to remove the line.

Tested on: 
- Firefox: 111.0b8
- Google Chrome: 111.0.5563.64
- Brave: version 1.51.24 (chromium: 111.0.5563.64)