### PR TITLE
Add support for Chromium based browser

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,6 +16,11 @@
  * For license information on the libraries used, see LICENSE.
  */
 
+// Support for Chrome
+if (typeof browser === "undefined") {
+  var browser = chrome;
+}
+
 let bangs = {};
 // Fetch Bangs from DuckDuckGo and load custom Bangs.
 (async () => {
@@ -104,10 +109,7 @@ browser.webRequest.onBeforeRequest.addListener(
 );
 
 function updateTab(tabId, url) {
-  const updateProperties = {
-    loadReplace: false,
-    url: url,
-  };
+  const updateProperties = { url };
   if (tabId != null) {
     browser.tabs.update(tabId, updateProperties);
   } else {
@@ -115,7 +117,7 @@ function updateTab(tabId, url) {
   }
 }
 
-browser.action.onClicked.addListener(function () {
+browser.action.onClicked.addListener(() => {
   browser.tabs.create({
     url: browser.runtime.getURL("options/options.html"),
   });

--- a/manifest.json
+++ b/manifest.json
@@ -360,6 +360,7 @@
   ],
 
   "background": {
+    "service_worker": "background.js",
     "scripts": ["background.js"]
   },
 


### PR DESCRIPTION
Added support for Chromium-based browsers. I tested the code in both Chrome <sup>129.0.6643.2 dev (arm64)</sup> & Firefox <sup>130.0b3 (64-bit)</sup>, and it works perfectly.

### Changes

- Using `chrome.*` instead of `browser.*` for _only_ Chromium-based browsers, as [requested](https://github.com/dmlls/yang/pull/3#issuecomment-1465886204) to use `browser.*` for the added advantages in Firefox.
- Added both `background.service_worker` & `background.scripts` to **manifest.json**. As mentioned [here](https://stackoverflow.com/a/78088358/10395681), this works, _but_ it results in warnings in both Firefox and Chrome about the other value being unrecognized.
- Removed [`loadReplace`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update#loadreplace) as there is no counterpart in the [Chromium side](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-update).