### PR TITLE
v0.9.26

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. Linux 6.10.6]
- - Browser [e.g. Firefox]
- - Version [e.g. 129.0.2]
+
+- OS: [e.g. Linux 6.10.6]
+- Browser [e.g. Firefox]
+- Version [e.g. 129.0.2]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. Fairphone 4]
- - OS: [e.g. Android 14]
- - Browser [e.g. Firefox]
- - Version [e.g. 129.0.2]
+
+- Device: [e.g. Fairphone 4]
+- OS: [e.g. Android 14]
+- Browser [e.g. Firefox]
+- Version [e.g. 129.0.2]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: ""
 labels: feature request
-assignees: ''
-
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/background.js
+++ b/background.js
@@ -29,7 +29,7 @@ if (typeof browser === "undefined") {
 }
 
 (async () => {
-  fetchSettings(false);
+  await fetchSettings(false);
 })();
 
 browser.webRequest.onBeforeRequest.addListener(
@@ -196,11 +196,12 @@ async function updateStorageSchema() {
     await browser.storage.sync.clear().then(
       async function onCleared() {
         await browser.storage.sync.set(sortedBangs).then(
-          function onSet() {
-            fetchSettings(true);
+          async function onSet() {
+            await fetchSettings(true);
           },
           async function onError(error) {
             await browser.storage.sync.set(sortedBangs); // Retry
+            await fetchSettings(true);
           },
         );
       },

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{0a3250b1-58e0-48cb-9383-428f5adc3dc1}",
-      "strict_min_version": "112.0"
+      "strict_min_version": "115.0"
     },
     "gecko-android": {
       "strict_min_version": "120.0"

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yang! - Yet Another Bangs anywhere extension",
   "description": "An open-source, lightweight Firefox extension that allows using DuckDuckGo Bangs anywhere.",
   "homepage_url": "https://github.com/dmlls/yang",
-  "version": "0.9.24",
+  "version": "0.9.26",
 
   "browser_specific_settings": {
     "gecko": {

--- a/options/add_edit_bang.js
+++ b/options/add_edit_bang.js
@@ -154,7 +154,7 @@ function stripExclamation(string) {
   return string.replace(/^!+|!+$/g, "");
 }
 
-async function setItem() {
+function setItem() {
   window.location.replace("options.html");
 }
 

--- a/options/add_edit_bang.js
+++ b/options/add_edit_bang.js
@@ -154,7 +154,7 @@ function stripExclamation(string) {
   return string.replace(/^!+|!+$/g, "");
 }
 
-function setItem() {
+async function setItem() {
   window.location.replace("options.html");
 }
 
@@ -173,10 +173,22 @@ async function saveCustomBang() {
       // If the bang has changed and does not already exist ->
       // Delete the previous one first.
       await browser.storage.sync.remove(saveButton.bangKey);
+      await browser.storage.session.remove(saveButton.bangKey);
     }
-    browser.storage.sync
-      .set({ [inputtedBangKey]: inputtedBang })
-      .then(setItem, onError);
+    await browser.storage.sync.set({ [inputtedBangKey]: inputtedBang }).then(
+      function onSet() {
+        browser.storage.session
+          .set({
+            [inputtedBangKey]: {
+              url: inputtedBang.url,
+              urlEncodeQuery: inputtedBang.urlEncodeQuery,
+              openBaseUrl: inputtedBang.openBaseUrl,
+            },
+          })
+          .then(setItem, onError);
+      },
+      function onError(error) {},
+    );
   }
 }
 

--- a/options/add_edit_bang.js
+++ b/options/add_edit_bang.js
@@ -232,6 +232,7 @@ if (mode === "edit") {
   );
 } else {
   saveButton.last = last;
+  document.getElementById("name").focus(); // focus first field
 }
 saveButton.mode = mode;
 saveButton.bangKey = bangKey;

--- a/options/export_import.js
+++ b/options/export_import.js
@@ -17,7 +17,7 @@
  */
 
 export { BACKUP_VERSION, BackupFields, exportSettings, importSettings };
-import { PreferencePrefix, getBangKey } from "../utils.js";
+import { PreferencePrefix, fetchSettings, getBangKey } from "../utils.js";
 
 const BACKUP_VERSION = "1.1";
 
@@ -99,9 +99,14 @@ async function importSettings(file) {
         order++;
       }
       preferences.set(PreferencePrefix.BANG_SYMBOL, bangSymbol);
-      await browser.storage.sync.set(Object.fromEntries(preferences));
-      alert("Settings imported successfully!");
-      window.location.href = "options.html";
+      browser.storage.sync.set(Object.fromEntries(preferences)).then(
+        async function onSet() {
+          fetchSettings(true);
+          alert("Settings imported successfully!");
+          window.location.href = "options.html";
+        },
+        function onError(error) {},
+      );
     } catch (error) {
       console.error("Error importing settings:", error);
       alert(

--- a/options/export_import.js
+++ b/options/export_import.js
@@ -64,7 +64,7 @@ async function importSettings(file) {
     const preferences = new Map();
     try {
       const neededFields = ["name", "url", "bang", "urlEncodeQuery"];
-      let readBackup = JSON.parse(event.target.result);
+      const readBackup = JSON.parse(event.target.result);
       let readBangs = {};
       const backupKeys = Object.keys(readBackup);
       // Backup version < 1.0.
@@ -101,7 +101,7 @@ async function importSettings(file) {
       preferences.set(PreferencePrefix.BANG_SYMBOL, bangSymbol);
       browser.storage.sync.set(Object.fromEntries(preferences)).then(
         async function onSet() {
-          fetchSettings(true);
+          await fetchSettings(true);
           alert("Settings imported successfully!");
           window.location.href = "options.html";
         },

--- a/options/options.html
+++ b/options/options.html
@@ -69,8 +69,8 @@
       </div>
       <div class="footer">
         <code id="version"
-          ><a href="https://github.com/dmlls/yang/releases/tag/v0.9.24"
-            >v0.9.24</a
+          ><a href="https://github.com/dmlls/yang/releases/tag/v0.9.26"
+            >v0.9.26</a
           ></code
         >
         <a

--- a/options/options.js
+++ b/options/options.js
@@ -131,7 +131,7 @@ function deleteBang(e) {
   );
 }
 
-async function undoDeletion(bang) {
+function undoDeletion(bang) {
   browser.storage.sync.set({ [getBangKey(bang.bang)]: bang }).then(
     function onSet() {
       browser.storage.session

--- a/options/options.js
+++ b/options/options.js
@@ -98,19 +98,26 @@ function deleteBang(e) {
       const bang = item[bangKey];
       browser.storage.sync.remove(bangKey).then(
         function onRemoved() {
-          row.remove();
-          const table = document.getElementById("bangs-table");
-          if (table.rows.length === 1) {
-            // Empty table.
-            const noBangsLabel = document.getElementById("no-bangs");
-            noBangsLabel.style.visibility = "visible";
-          }
-          displayToast(
-            bangKey,
-            `Bang '${bang.bang}' deleted.`,
-            "Undo",
-            undoDeletion,
-            bang,
+          browser.storage.session.remove(bangKey).then(
+            function onRemoved() {
+              row.remove();
+              const table = document.getElementById("bangs-table");
+              if (table.rows.length === 1) {
+                // Empty table.
+                const noBangsLabel = document.getElementById("no-bangs");
+                noBangsLabel.style.visibility = "visible";
+              }
+              displayToast(
+                bangKey,
+                `Bang '${bang.bang}' deleted.`,
+                "Undo",
+                undoDeletion,
+                bang,
+              );
+            },
+            function onError() {
+              // TODO: Handle errors.
+            },
           );
         },
         function onError() {
@@ -124,14 +131,25 @@ function deleteBang(e) {
   );
 }
 
-function undoDeletion(bang) {
+async function undoDeletion(bang) {
   browser.storage.sync.set({ [getBangKey(bang.bang)]: bang }).then(
-    function setItem() {
-      window.location.reload();
+    function onSet() {
+      browser.storage.session
+        .set({
+          [getBangKey(bang.bang)]: {
+            url: bang.url,
+            urlEncodeQuery: bang.urlEncodeQuery,
+            openBaseUrl: bang.openBaseUrl,
+          },
+        })
+        .then(
+          function onSet() {
+            window.location.reload();
+          },
+          function onError() {},
+        );
     },
-    function onError() {
-      // TODO: Handle error.
-    },
+    function onError(error) {},
   );
 }
 

--- a/options/settings.js
+++ b/options/settings.js
@@ -34,7 +34,7 @@ function success() {
   window.location.replace("options.html");
 }
 
-async function saveSettings() {
+function saveSettings() {
   const settings = {};
   for (const [settingName, settingValue] of storedSettings) {
     settings[settingName] = settingValue.element.value || settingValue.default;

--- a/options/settings.js
+++ b/options/settings.js
@@ -39,10 +39,15 @@ async function saveSettings() {
   for (const [settingName, settingValue] of storedSettings) {
     settings[settingName] = settingValue.element.value || settingValue.default;
   }
-  browser.storage.sync.set(settings).then(success, onError);
+  browser.storage.sync.set(settings).then(
+    function onSet() {
+      browser.storage.session.set(settings).then(success, onError);
+    },
+    function onError(error) {},
+  );
 }
 
-function onError() {}
+function onError(error) {}
 
 function saveOnCtrlEnter(e) {
   if ((e.ctrlKey || e.metaKey) && (e.keyCode === 13 || e.keyCode === 10)) {
@@ -55,7 +60,7 @@ function saveOnCtrlEnter(e) {
 browser.storage.sync.get(Array.from(storedSettings.keys())).then(
   function onGot(items) {
     for (const [settingName, settingValue] of storedSettings) {
-      if (items.hasOwnProperty(settingName)) {
+      if (Object.hasOwn(items, settingName)) {
         settingValue.element.setAttribute("value", items[settingName]);
       } else {
         settingValue.element.setAttribute("value", settingValue.default);

--- a/utils.js
+++ b/utils.js
@@ -78,7 +78,7 @@ async function fetchSettings(update = false) {
   settings[getBangKey("waybackmachine")].urlEncodeQuery = false;
   // Fetch custom bangs.
   await browser.storage.sync.get().then(
-    async function onGot(storedSettings) {
+    function onGot(storedSettings) {
       for (let [bangKey, bangInfo] of Object.entries(storedSettings)) {
         // In the session storage, we don't need all the bang values stored in
         // the sync storage. Here, we filter them out.
@@ -105,6 +105,7 @@ async function fetchSettings(update = false) {
       // TODO: Handle error.
     },
   );
+  return null;
 }
 
 function getBangKey(bang) {

--- a/utils.js
+++ b/utils.js
@@ -16,7 +16,7 @@
  * For license information on the libraries used, see LICENSE.
  */
 
-export { PreferencePrefix, getBangKey };
+export { PreferencePrefix, Defaults, fetchSettings, getBangKey };
 
 // Prefixes added to the storage keys to differentiate between different types
 // of settings.
@@ -25,6 +25,87 @@ const PreferencePrefix = Object.freeze({
   BANG_SYMBOL: "#symbol#",
   SEARCH_ENGINE: "#engine#",
 });
+
+const Defaults = Object.freeze({
+  BANG_SYMBOL: "!",
+});
+
+async function fetchSettings(update = false) {
+  if (!update) {
+    // Check whether there are any settings are loaded. We look for, e.g.,
+    // the bang symbol key. If no settings are loaded, we fetch them and retry
+    // A more elegant solution would be `StorageArea.getBytesInUse()`, but
+    // it's not supported for `storage.session`.
+    const updated = await browser.storage.session
+      .get(PreferencePrefix.BANG_SYMBOL)
+      .then(
+        function onGot(item) {
+          // Any matches?
+          return Object.hasOwn(item, PreferencePrefix.BANG_SYMBOL);
+        },
+        function onError(error) {
+          // TODO: Handle error.
+        },
+      );
+    if (updated) {
+      return null;
+    }
+  }
+  const settings = {};
+  let defaultBangs = [];
+  const bangApis = [
+    "https://raw.githubusercontent.com/kagisearch/bangs/main/data/bangs.json",
+    "https://duckduckgo.com/bang.js",
+  ];
+  for (const api of bangApis) {
+    try {
+      const res = await fetch(new Request(api));
+      defaultBangs = await res.json();
+      break;
+    } catch (error) {
+      // retry
+    }
+  }
+  for (const bang of defaultBangs) {
+    settings[getBangKey(bang.t)] = {
+      url: bang.u,
+      urlEncodeQuery: true, // default value
+      openBaseUrl: true, // default value
+    };
+  }
+  // Exceptions (unfortunately, default bangs do not expose this info).
+  settings[getBangKey("wayback")].urlEncodeQuery = false;
+  settings[getBangKey("waybackmachine")].urlEncodeQuery = false;
+  // Fetch custom bangs.
+  await browser.storage.sync.get().then(
+    async function onGot(storedSettings) {
+      for (let [bangKey, bangInfo] of Object.entries(storedSettings)) {
+        // In the session storage, we don't need all the bang values stored in
+        // the sync storage. Here, we filter them out.
+        if (bangKey.startsWith(PreferencePrefix.BANG)) {
+          bangInfo = {
+            url: bangInfo.url,
+            urlEncodeQuery: bangInfo.urlEncodeQuery,
+            openBaseUrl: bangInfo.openBaseUrl,
+          };
+        }
+        settings[bangKey] = bangInfo;
+      }
+      if (!Object.hasOwn(settings, PreferencePrefix.BANG_SYMBOL)) {
+        settings[PreferencePrefix.BANG_SYMBOL] = Defaults.BANG_SYMBOL;
+      }
+      browser.storage.session.clear().then(
+        function onCleared() {
+          browser.storage.session.set(settings);
+        },
+        function onError(error) {},
+      );
+    },
+    function onError(error) {
+      // TODO: Handle error.
+    },
+  );
+}
 
 function getBangKey(bang) {
   if (bang == null) {


### PR DESCRIPTION
<b>Bug Fixes</b>
<ul>
    <li>Bangs should again trigger without having to retry (see #20).</li>
</ul>

<b>Changed</b>
<ul>
    <li>When you add a new bang, the first text input will now be focused and ready for you to type.</li>
</ul>

<b>Did you know?</b>
<ul>
    <li>You can also use bangs as site shortcuts (without specifying <code>{{{s}}}</code>). For example, to quickly access the Yang! settings, you can add a bang <code>!y</code> with the URL of the extension (note that this URL might change every now and then).</li>
</ul>

<b>Non-user-facing Changes</b>
<ul>
    <li>This version embeds some performance improvements. For example, search engines tend to make a lot of requests aside from the search request itself (e.g., to pre-fetch data, telemetry, etc.). We now employ a more aggressive filtering, so that all these unrelated requests are not considered by Yang!.</li>
</ul>
