### PR TITLE
v0.9.30

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,22 +10,22 @@
    being hurt because they felt they "wasted their time" implementing a rejected
    feature.
 3. Once you have implemented your changes:
-   1.  Run the JavaScript linter (Node.js is required):
-       ```console
-       npx jshint *.js options/*.js
-       ```
-   2.  Run the CSS linter:
-       ```console
-       npx stylelint options/*.css
-       ```
+   1. Run the JavaScript linter (Node.js is required):
+      ```console
+      npx jshint *.js options/*.js
+      ```
+   2. Run the CSS linter:
+      ```console
+      npx stylelint options/*.css
+      ```
    3. Lint the extension:
       ```console
       npx web-ext lint
       ```
-   5.  Format the code:
-       ```console
-       npx prettier . --write
-       ```
+   4. Format the code:
+      ```console
+      npx prettier . --write
+      ```
 4. **Test the extension** thoroughly on both desktop and Android.
 5. Finally, open a pull request. Congratulations, you made it! 🥳
 

--- a/background.js
+++ b/background.js
@@ -23,7 +23,7 @@ import {
   getBangKey,
 } from "./utils.js";
 
-// Support for Chrome.
+// Support for Chromium.
 if (typeof browser === "undefined") {
   globalThis.browser = chrome;
 }
@@ -154,7 +154,7 @@ browser.webRequest.onBeforeRequest.addListener(
   {
     urls: ["<all_urls>"],
   },
-  ["blocking", "requestBody"],
+  ["requestBody"],
 );
 
 function updateTab(tabId, url) {

--- a/background.js
+++ b/background.js
@@ -32,11 +32,9 @@ if (typeof browser === "undefined") {
   await fetchSettings(false);
 })();
 
-browser.runtime.onStartup.addListener(
-  async () => {
-    await fetchSettings(false);
-  }
-);
+browser.runtime.onStartup.addListener(async () => {
+  await fetchSettings(false);
+});
 
 browser.webRequest.onBeforeRequest.addListener(
   async (details) => {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yang! - Yet Another Bangs anywhere extension",
   "description": "An open-source, lightweight Firefox extension that allows using DuckDuckGo Bangs anywhere.",
   "homepage_url": "https://github.com/dmlls/yang",
-  "version": "0.9.29",
+  "version": "0.9.30",
 
   "browser_specific_settings": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
     "256": "icons/icon-256.png"
   },
 
-  "permissions": ["webRequest", "webRequestBlocking", "activeTab", "storage"],
+  "permissions": ["webRequest", "activeTab", "storage"],
 
   "host_permissions": [
     "*://www.google.com/search*",

--- a/options/add_edit_bang.css
+++ b/options/add_edit_bang.css
@@ -7,6 +7,7 @@
 }
 
 body {
+  opacity: 0; /* Set to 1 when the contents are loaded. */
   font-family: InterVariable, sans-serif;
   font-size: 1rem;
   margin: 0;

--- a/options/add_edit_bang.css
+++ b/options/add_edit_bang.css
@@ -8,6 +8,7 @@
 
 body {
   font-family: InterVariable, sans-serif;
+  font-size: 1rem;
   margin: 0;
   padding: 0;
   background-color: #f5f5f5;
@@ -45,6 +46,12 @@ input {
   border: none;
   border: solid 1.5px #aaa;
   border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+input::placeholder {
+  opacity: 0.7;
+  color: #5c5c5c;
 }
 
 .button-container {
@@ -63,7 +70,7 @@ button {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  font-size: medium;
+  font-size: 1rem;
   transition:
     border-radius 0.5s ease,
     background 0.3s ease;
@@ -86,6 +93,7 @@ button svg {
 }
 
 .back-container {
+  font-size: 0.9rem;
   text-align: left;
 }
 
@@ -122,11 +130,7 @@ button svg {
   text-align: start;
   width: 100%;
   color: red;
-  font-size: small;
-}
-
-input::placeholder {
-  color: #666;
+  font-size: 0.87rem;
 }
 
 .tooltip-text {

--- a/options/add_edit_bang.html
+++ b/options/add_edit_bang.html
@@ -88,7 +88,6 @@
             <input type="checkbox" id="openBaseUrl" name="openBaseUrl" />
             <label for="openBaseUrl">Open Base URL</label>
           </div>
-
           <div class="button-container">
             <button type="button" id="save">
               <svg

--- a/options/add_edit_bang.js
+++ b/options/add_edit_bang.js
@@ -18,6 +18,11 @@
 
 import { getBangKey } from "../utils.js";
 
+// Support for Chromium.
+if (typeof browser === "undefined") {
+  globalThis.browser = chrome;
+}
+
 const FormFields = Object.freeze({
   NAME: "name",
   URL: "url",

--- a/options/add_edit_bang.js
+++ b/options/add_edit_bang.js
@@ -160,7 +160,7 @@ function stripExclamation(string) {
 }
 
 function setItem() {
-  window.location.replace("options.html");
+  window.location.href = "options.html";
 }
 
 function onError() {}

--- a/options/add_edit_bang.js
+++ b/options/add_edit_bang.js
@@ -242,6 +242,7 @@ if (mode === "edit") {
 saveButton.mode = mode;
 saveButton.bangKey = bangKey;
 saveButton.addEventListener("click", saveCustomBang, false);
+document.body.style.opacity = "1";
 
 // Save with Ctrl+Enter or Cmd+Enter.
 const inputFields = document.getElementsByClassName("input-field");

--- a/options/export_import.js
+++ b/options/export_import.js
@@ -19,6 +19,11 @@
 export { BACKUP_VERSION, BackupFields, exportSettings, importSettings };
 import { PreferencePrefix, fetchSettings, getBangKey } from "../utils.js";
 
+// Support for Chromium.
+if (typeof browser === "undefined") {
+  globalThis.browser = chrome;
+}
+
 const BACKUP_VERSION = "1.1";
 
 const BackupFields = Object.freeze({

--- a/options/options.css
+++ b/options/options.css
@@ -176,7 +176,7 @@ h1 {
 
 .bang {
   font-family: monospace;
-  font-size: 0.76rem;
+  font-size: 0.75rem;
   font-weight: bold;
   color: #7914ad;
   background-color: #f4f4f4;
@@ -187,7 +187,7 @@ h1 {
 
 #no-bangs {
   color: #585858;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   margin: 15px 0;
 }
 

--- a/options/options.css
+++ b/options/options.css
@@ -8,7 +8,7 @@
 
 body {
   font-family: InterVariable, sans-serif;
-  font-size: 1.1em;
+  font-size: 1.1rem;
   margin: 0;
   padding: 0;
   background-color: #f5f5f5;
@@ -26,7 +26,7 @@ body {
   background-color: #fff;
   box-shadow: 0 0 10px #ebebeb;
   border-radius: 8px;
-  padding: 2em;
+  padding: 2rem;
   overflow-x: hidden;
 }
 
@@ -105,7 +105,7 @@ h1 {
   table-layout: fixed;
   border-collapse: collapse;
   border-radius: 8px 8px 0 0;
-  font-size: 0.9em;
+  font-size: 0.95rem;
   font-family: sans-serif;
   text-align: left;
   box-shadow: 0 0 20px #ebebeb;
@@ -175,17 +175,18 @@ h1 {
 
 .bang {
   font-family: monospace;
+  font-size: 0.76rem;
+  font-weight: bold;
+  color: #7914ad;
   background-color: #f4f4f4;
-  padding: 0.2em;
+  padding: 0.2rem;
   border: 1px solid #ccc;
   border-radius: 4px;
-  color: #7914ad;
-  font-weight: bold;
 }
 
 #no-bangs {
   color: #585858;
-  font-size: 0.9em;
+  font-size: 0.9rem;
   margin: 15px 0;
 }
 
@@ -194,7 +195,7 @@ h1 {
   width: 100%;
   margin-top: 20px;
   justify-content: space-between;
-  font-size: small;
+  font-size: 0.85rem;
 }
 
 .footer a {
@@ -202,7 +203,7 @@ h1 {
 }
 
 #version {
-  font-size: medium;
+  font-size: 0.8rem;
 }
 
 #version a:link,
@@ -230,7 +231,7 @@ h1 {
   color: yellow;
   border: none;
   text-decoration: underline;
-  font-size: 16px;
+  font-size: 1rem;
   cursor: pointer;
 }
 

--- a/options/options.css
+++ b/options/options.css
@@ -7,6 +7,7 @@
 }
 
 body {
+  opacity: 0; /* Set to 1 when the contents are loaded. */
   font-family: InterVariable, sans-serif;
   font-size: 1.1rem;
   margin: 0;

--- a/options/options.html
+++ b/options/options.html
@@ -71,8 +71,8 @@
       </div>
       <div class="footer">
         <code id="version"
-          ><a href="https://github.com/dmlls/yang/releases/tag/v0.9.29"
-            >v0.9.29</a
+          ><a href="https://github.com/dmlls/yang/releases/tag/v0.9.30"
+            >v0.9.30</a
           ></code
         >
         <a

--- a/options/options.js
+++ b/options/options.js
@@ -16,7 +16,7 @@
  * For license information on the libraries used, see LICENSE.
  */
 
-import { PreferencePrefix, getBangKey } from "../utils.js";
+import { PreferencePrefix, fetchSettings, getBangKey } from "../utils.js";
 
 // Support for Chromium.
 if (typeof browser === "undefined") {
@@ -101,7 +101,7 @@ function deleteBang(e) {
       browser.storage.sync.remove(bangKey).then(
         function onRemoved() {
           browser.storage.session.remove(bangKey).then(
-            function onRemoved() {
+            async function onRemoved() {
               const rowIndex = row.rowIndex;
               row.remove();
               // Remove sets rowIndex to -1 so we restore it.
@@ -126,6 +126,7 @@ function deleteBang(e) {
                 row,
                 bang,
               ]);
+              await fetchSettings(true);
             },
             function onError() {
               // TODO: Handle errors.

--- a/options/options.js
+++ b/options/options.js
@@ -146,6 +146,7 @@ function undoDeletion(bang) {
         })
         .then(
           function onSet() {
+            document.body.style.opacity = "0";
             window.location.reload();
           },
           function onError() {},
@@ -194,5 +195,6 @@ function undoAction() {
 }
 
 browser.storage.sync.get().then(onGot, onError);
+document.body.style.opacity = "1";
 const addBangButton = document.getElementById("add-bang");
 addBangButton.addEventListener("click", addBang, false);

--- a/options/options.js
+++ b/options/options.js
@@ -107,7 +107,9 @@ function deleteBang(e) {
               const table = document.getElementById("bangs-table");
               if (table.rows.length === 1) {
                 // Empty table.
-                document.getElementById("no-bangs").style.removeProperty("display");
+                document
+                  .getElementById("no-bangs")
+                  .style.removeProperty("display");
               }
               displayToast(
                 bangKey,

--- a/options/options.js
+++ b/options/options.js
@@ -18,6 +18,11 @@
 
 import { PreferencePrefix, getBangKey } from "../utils.js";
 
+// Support for Chromium.
+if (typeof browser === "undefined") {
+  globalThis.browser = chrome;
+}
+
 function onGot(allBangs) {
   // Get only the bang values, sorted by order.
   const sortedBangs = Object.entries(allBangs)

--- a/options/options.js
+++ b/options/options.js
@@ -80,16 +80,14 @@ function onError(error) {
 
 function addBang(e) {
   const last = e.currentTarget.last == null ? -1 : e.currentTarget.last;
-  window.location.replace(`add_edit_bang.html?mode=add&last=${last}`);
+  window.location.href = `add_edit_bang.html?mode=add&last=${last}`;
 }
 
 function editBang(e) {
   const row = e.currentTarget.parentNode.parentNode;
   const bang = row.cells[1].textContent;
   const addBangButton = document.getElementById("add-bang");
-  window.location.replace(
-    `add_edit_bang.html?mode=edit&bang=${bang}&last=${addBangButton.last}`,
-  );
+  window.location.href = `add_edit_bang.html?mode=edit&bang=${bang}&last=${addBangButton.last}`;
 }
 
 function deleteBang(e) {

--- a/options/settings.css
+++ b/options/settings.css
@@ -7,6 +7,7 @@
 }
 
 body {
+  opacity: 0; /* Set to 1 when the contents are loaded. */
   font-family: InterVariable, sans-serif;
   font-size: 1rem;
   margin: 0;

--- a/options/settings.css
+++ b/options/settings.css
@@ -8,6 +8,7 @@
 
 body {
   font-family: InterVariable, sans-serif;
+  font-size: 1rem;
   margin: 0;
   padding: 0;
   background-color: #f5f5f5;
@@ -20,7 +21,7 @@ body {
   background-color: #fff;
   box-shadow: 0 0 10px rgba(0 0 0 0.1);
   border-radius: 8px;
-  padding: 2em;
+  padding: 2rem;
   overflow: hidden;
 }
 
@@ -34,6 +35,7 @@ h1 {
 h2 {
   color: #e15e49;
   font-weight: normal;
+  font-size: 1.5rem;
   text-align: start;
 }
 
@@ -41,6 +43,7 @@ label {
   margin-bottom: 5px;
   text-align: start;
   width: 100%;
+  font-size: 1rem;
 }
 
 input {
@@ -73,7 +76,7 @@ button {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  font-size: medium;
+  font-size: 1rem;
   transition:
     border-radius 0.5s ease,
     background 0.3s ease;
@@ -117,6 +120,7 @@ button svg {
 }
 
 .back-container {
+  font-size: 0.9rem;
   text-align: left;
 }
 
@@ -137,7 +141,7 @@ button svg {
 }
 
 .setting-detail {
-  font-size: small;
+  font-size: 0.82rem;
 }
 
 input::placeholder {

--- a/options/settings.js
+++ b/options/settings.js
@@ -36,7 +36,7 @@ storedSettings.set(PreferencePrefix.BANG_SYMBOL, {
 });
 
 function success() {
-  window.location.replace("options.html");
+  window.location.href = "options.html";
 }
 
 function saveSettings() {

--- a/options/settings.js
+++ b/options/settings.js
@@ -24,6 +24,11 @@ import {
   importSettings,
 } from "./export_import.js";
 
+// Support for Chromium.
+if (typeof browser === "undefined") {
+  globalThis.browser = chrome;
+}
+
 let storedSettings = new Map();
 storedSettings.set(PreferencePrefix.BANG_SYMBOL, {
   element: document.getElementById("bang-symbol"),

--- a/options/settings.js
+++ b/options/settings.js
@@ -76,6 +76,7 @@ browser.storage.sync.get(Array.from(storedSettings.keys())).then(
     // TODO: Handle error.
   },
 );
+document.body.style.opacity = "1";
 const saveButton = document.getElementById("save");
 saveButton.addEventListener("click", saveSettings, false);
 

--- a/utils.js
+++ b/utils.js
@@ -91,7 +91,10 @@ async function fetchSettings(update = false) {
         }
         settings[bangKey] = bangInfo;
       }
-      if (!Object.hasOwn(settings, PreferencePrefix.BANG_SYMBOL) || !settings[PreferencePrefix.BANG_SYMBOL]) {
+      if (
+        !Object.hasOwn(settings, PreferencePrefix.BANG_SYMBOL) ||
+        !settings[PreferencePrefix.BANG_SYMBOL]
+      ) {
         settings[PreferencePrefix.BANG_SYMBOL] = Defaults.BANG_SYMBOL;
       }
       browser.storage.session.clear().then(

--- a/utils.js
+++ b/utils.js
@@ -32,10 +32,10 @@ const Defaults = Object.freeze({
 
 async function fetchSettings(update = false) {
   if (!update) {
-    // Check whether there are any settings are loaded. We look for, e.g.,
-    // the bang symbol key. If no settings are loaded, we fetch them and retry
-    // A more elegant solution would be `StorageArea.getBytesInUse()`, but
-    // it's not supported for `storage.session`.
+    // Check if any settings are loaded. We look for, e.g., the bang symbol key.
+    // If no settings are loaded, we fetch them and retry. A more elegant
+    // solution would be `StorageArea.getBytesInUse()`, but it's not supported
+    // for `storage.session`.
     const updated = await browser.storage.session
       .get(PreferencePrefix.BANG_SYMBOL)
       .then(


### PR DESCRIPTION
<b>Improvements</b>
<ul>
    <li>When undoing a bang deletion, the bang is simply added back to the table, without reloading the entire page.</li>
</ul>

<b>Bug Fixes</b>
<ul>
    <li>Fix default bang not being restored when deleting a custom bang that overrides a default bang.</li>
</ul>

<b>Non-user-facing Changes</b>
<ul>
    <li>We no longer use <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest">blocking web requests</a> to trigger bangs. This is due to Google's Manifest V3 <a href="https://developer.chrome.com/docs/extensions/develop/migrate/blocking-web-requests">not supporting blocking web requests</a>. I do not see a way of triggering the bangs with the new <a href="https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest">Declarative Net Request API</a>. The extension seems to work fine without the blocking requests, but if it turns out it doesn't, I will halt the Chromium support and add back the blocking requests.</li>
</ul>