### PR TITLE
v1.0.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -224,6 +224,8 @@
 
     "*://duckduckgo.com/bang.js",
     "*://duckduckgo.com/*",
+    "*://lite.duckduckgo.com/lite*",
+    "*://html.duckduckgo.com/html*",
 
     "*://search.brave.com/search*",
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yang! - Yet Another Bangs anywhere extension",
   "description": "An open-source, lightweight extension that allows using DuckDuckGo-like bangs anywhere.",
   "homepage_url": "https://github.com/dmlls/yang",
-  "version": "1.0.2",
+  "version": "1.0.3",
 
   "browser_specific_settings": {
     "gecko": {

--- a/options/options.html
+++ b/options/options.html
@@ -71,8 +71,8 @@
       </div>
       <div class="footer">
         <code id="version"
-          ><a href="https://github.com/dmlls/yang/releases/tag/v1.0.2"
-            >v1.0.2</a
+          ><a href="https://github.com/dmlls/yang/releases/tag/v1.0.3"
+            >v1.0.3</a
           ></code
         >
         <a


### PR DESCRIPTION
**Added**
- Support for DuckDuckGo [Lite](https://lite.duckduckgo.com/lite/) and [HTML](https://html.duckduckgo.com/html/) ([#44](https://github.com/dmlls/yang/issues/44)).