### PR TITLE
v1.0.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yang! - Yet Another Bangs anywhere extension",
   "description": "An open-source, lightweight extension that allows using DuckDuckGo-like bangs anywhere.",
   "homepage_url": "https://github.com/dmlls/yang",
-  "version": "1.0.5",
+  "version": "1.0.6",
 
   "browser_specific_settings": {
     "gecko": {

--- a/options/options.html
+++ b/options/options.html
@@ -71,8 +71,8 @@
       </div>
       <div class="footer">
         <code id="version"
-          ><a href="https://github.com/dmlls/yang/releases/tag/v1.0.5"
-            >v1.0.5</a
+          ><a href="https://github.com/dmlls/yang/releases/tag/v1.0.6"
+            >v1.0.6</a
           ></code
         >
         <a

--- a/utils.js
+++ b/utils.js
@@ -88,7 +88,7 @@ async function fetchSettings(update = false) {
   // Exceptions for DDG (unfortunately, default bangs do not expose this info).
   const wbm = settings[getBangKey("archived")];
   if (wbm && wbm.length > 0) {
-      wbm[0].urlEncodeQuery = false;
+    wbm[0].urlEncodeQuery = false;
   }
   // Fetch custom bangs.
   await browser.storage.sync.get().then(


### PR DESCRIPTION
**Hotfix**
- Fix default bangs no longer working. This was caused by a change in the Kagi bangs schema after https://github.com/kagisearch/bangs/pull/259 was merged.