### PR TITLE
v2.0.6

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -44,7 +44,6 @@ const BangProviders = Object.freeze({
     endpoints: [
       "https://raw.githubusercontent.com/kagisearch/bangs/main/data/bangs.json",
       "https://raw.githubusercontent.com/kagisearch/bangs/main/data/kagi_bangs.json",
-      "https://raw.githubusercontent.com/kagisearch/bangs/main/data/assistant_bangs.json",
     ],
   },
   DDG: {


### PR DESCRIPTION
**Fixed**
- An update in upstream Kagi bangs had broken the default bang fetching when this provider was selected.