### PR TITLE
v2.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ issue](https://github.com/dmlls/yang/issues/new/choose) and we'll add it!
 </details>
 
 <details>
+  <summary><b>Why is it not allowed to set an <code>about:</code> page as the target URL?</b></summary>
+  <p>
+     This restriction comes from the browser itself. <code>about:</code> pages
+     are considered priviledged URLs and are not allowed for security reasons
+     (<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update#url">docs</a>).
+  </p>
+</details>
+
+<details>
   <summary><b>Does Yang collect any data?</b></summary>
   <p>Yang does not collect any kind of data and never ever will!</p>
 </details>

--- a/background.js
+++ b/background.js
@@ -79,7 +79,6 @@ browser.webRequest.onBeforeRequest.addListener(
       ".woff2",
       "/ia",
       "/asset", // Kagi
-      "/socket", // Kagi
       "/static-assets", // DuckDuckGo
       "/_next", // DuckDuckGo
       "/dist", // DuckDuckGo

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yang! - Yet Another Bangs anywhere extension",
   "description": "An open-source, lightweight extension that allows using DuckDuckGo-like bangs anywhere.",
   "homepage_url": "https://github.com/dmlls/yang",
-  "version": "2.0.5",
+  "version": "2.0.6",
 
   "browser_specific_settings": {
     "gecko": {

--- a/options/add_edit_bang.js
+++ b/options/add_edit_bang.js
@@ -69,6 +69,14 @@ function validateUrl(inputElement, containerElement) {
   const urlString = inputElement.value.trim();
   try {
     url = decodeURIComponent(new URL(urlString));
+    if (url.startsWith("about:")) {
+      showErrorMessage(
+        inputElement,
+        containerElement,
+        "Privileged URLs (about:) are not allowed for security reasons.",
+      );
+      return null;
+    }
   } catch (_) {
     showErrorMessage(
       inputElement,

--- a/options/options.html
+++ b/options/options.html
@@ -146,8 +146,8 @@
       <div id="pagination"></div>
       <div id="footer">
         <code id="version"
-          ><a href="https://github.com/dmlls/yang/releases/tag/v2.0.5"
-            >v2.0.5</a
+          ><a href="https://github.com/dmlls/yang/releases/tag/v2.0.6"
+            >v2.0.6</a
           ></code
         >
         <a


### PR DESCRIPTION
**Fixed**
- Bangs wouldn't trigger from Kagi results page.

**Changed**
- It's no longer possible to set an `about:` URL as the target URL. These URLs are not allowed by browsers for security reasons (see [docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update#url)). Until now, Yang accepted these URLs, but the bang wouldn't trigger anything (https://github.com/dmlls/yang/issues/73).