### PR TITLE
v2.0.8

### DIFF
--- a/background.js
+++ b/background.js
@@ -45,6 +45,8 @@ browser.webRequest.onBeforeRequest.addListener(
     const include = [
       "/search",
       "duckduckgo.com/?",
+      "duckduckgo.com/lite",
+      "duckduckgo.com/html",
       "/dsearch", // Startpage add-on
       "/web?", // swisscows & ask.com
       "qwant.com/",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yang! - Yet Another Bangs anywhere extension",
   "description": "An open-source, lightweight extension that allows using DuckDuckGo-like bangs anywhere.",
   "homepage_url": "https://github.com/dmlls/yang",
-  "version": "2.0.7",
+  "version": "2.0.8",
 
   "browser_specific_settings": {
     "gecko": {

--- a/options/options.html
+++ b/options/options.html
@@ -146,8 +146,8 @@
       <div id="pagination"></div>
       <div id="footer">
         <code id="version"
-          ><a href="https://github.com/dmlls/yang/releases/tag/v2.0.7"
-            >v2.0.7</a
+          ><a href="https://github.com/dmlls/yang/releases/tag/v2.0.8"
+            >v2.0.8</a
           ></code
         >
         <a


### PR DESCRIPTION
**Fixed**
- Bangs work again on [DuckDuckGo Lite](https://lite.duckduckgo.com/) and [DuckDuckGo HTML](https://html.duckduckgo.com/html) ([#76](https://github.com/dmlls/yang/issues/76)).